### PR TITLE
Rename output images to filenamepng

### DIFF
--- a/nb_lib/formatter.py
+++ b/nb_lib/formatter.py
@@ -41,13 +41,14 @@ class Formatter:
             body, resources = self.exporter.from_notebook_node(nb)
             return self.replace_image_names(body, resources, file)
 
-    def replace_image_names(self, body, resources, filename):
-        filename = os.path.basename(filename.replace(".ipynb", ""))
+    def replace_image_names(self, body, resources, file):
+        f_name = os.path.basename(file).replace(".ipynb", "")
         names = resources["outputs"].keys()
         new_outputs = {}
 
         for i, old_key in enumerate(names):
-            output_name = f"{filename}_{i}.png"
+            _, image_extension = os.path.splitext(old_key)
+            output_name = f"{f_name}_{i}{image_extension}"
             new_outputs[output_name] = resources["outputs"][old_key]
             body = body.replace(old_key, output_name)
 

--- a/nb_lib/formatter.py
+++ b/nb_lib/formatter.py
@@ -39,7 +39,20 @@ class Formatter:
         with open(file, "r", encoding=self.read_encoding) as f:
             nb = nbformat.read(f, as_version=4)
             body, resources = self.exporter.from_notebook_node(nb)
-            return body, resources
+            return self.replace_image_names(body, resources, file)
+
+    def replace_image_names(self, body, resources, filename):
+        filename = os.path.basename(filename.replace(".ipynb", ""))
+        names = resources["outputs"].keys()
+        new_outputs = {}
+
+        for i, old_key in enumerate(names):
+            output_name = f"{filename}_{i}.png"
+            new_outputs[output_name] = resources["outputs"][old_key]
+            body = body.replace(old_key, output_name)
+
+        resources["outputs"] = new_outputs
+        return body, resources
 
     def needs_format(self, file):
         f_path = self.dst_path(file)


### PR DESCRIPTION
At this time, convertor return, for every visual element, an _output_N1_N2.png_ image, with N1 and N2 numbers obtained from the notebook. 
This can cause problems, if two notebooks has different images with same N1 and N2 values: they step on each other and, at the end, you only have one of two images

With this changes, every notebook returns _notebookname_N.png_ with N iterating between 0 and IMG_QUANTITY. Therefore, image names are related only to the notebooks that belongs, and can't crush other notebooks images